### PR TITLE
Fix potential KeyError in extract_cpe when CNA container is missing

### DIFF
--- a/vulntrain/utils.py
+++ b/vulntrain/utils.py
@@ -74,7 +74,7 @@ def extract_cpe(data) -> list[str]:
                             )
 
     # default container
-    for elem in data["containers"]["cna"]["affected"]:
+    for elem in data.get("containers", {}).get("cna", {}).get("affected", []):
         if "cpes" in elem:
             vuln_cpes.extend(elem["cpes"])
 


### PR DESCRIPTION
The `extract_cpe` function in `vulntrain/utils.py` accesses `data["containers"]["cna"]["affected"]` with direct bracket notation, which raises a `KeyError` when a CVE entry does not contain the `cna` key under `containers` (e.g., CVEs in RESERVED or REJECTED state, or entries from non-CNA sources).

This fix replaces the unsafe dict access with `.get()` calls that gracefully return an empty list, matching the defensive pattern already used in other sections of the same function (the vulnrichment block already uses safe access via `containers.get("adp", [])` and `containers.get("cna", {}).get("affected", [])`).

**Change:**
```diff
-    for elem in data["containers"]["cna"]["affected"]:
+    for elem in data.get("containers", {}).get("cna", {}).get("affected", []):
```